### PR TITLE
Update scan() - use 'prune' in find

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1180,8 +1180,13 @@ scan() {
 		file_list_start=`date +"%s"`
 		tmpscandir="$tmpdir/scan.$RANDOM"
 		mkdir -p "$tmpscandir" ; chmod 700 $tmpscandir ; cd $tmpscandir
-		eout "{scan} executed eval $nice_command $find $spath $spath_tmpdirs -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group"
-		eval $nice_command $find /lmd_find/ $(echo $spath) $spath_tmpdirs -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group 2> /dev/null | grep -E -vf $ignore_paths > $find_results
+                if [ -s $ignore_paths ]; then
+                        for ignore_path in $(cat $ignore_paths); do
+                                find_prune="$find_prune -path $ignore_path -prune -o "
+                        done
+                fi
+		eout "{scan} executed eval $nice_command $find $spath $spath_tmpdirs $find_prune -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group"
+		eval $nice_command $find /lmd_find/ $(echo $spath) $spath_tmpdirs $find_prune -maxdepth $scan_max_depth $find_opts -type f $find_recentopts -size +${scan_min_filesize}c -size -$scan_max_filesize $include_regex -not -perm 000 $exclude_regex $ignore_fext $ignore_root $ignore_user $ignore_group 2> /dev/null | grep -E -vf $ignore_paths > $find_results
 		cd $tmpdir
 		rm -rf $tmpscandir
 		if [ "$rscan" = "1" ] && [ "$scan_export_filelist" == "1" ]; then


### PR DESCRIPTION
Update scan() function so that it used 'prune' in find to avoid searching in ignored paths (from $ignore_paths)